### PR TITLE
allow adding and removing tags

### DIFF
--- a/lib/creatubbles/creation.rb
+++ b/lib/creatubbles/creation.rb
@@ -33,6 +33,16 @@ class Creatubbles::Creation < Creatubbles::BaseObject
     @connection.put("creations/#{id}", :body => { 'data' => { 'type' => 'creations', 'attributes': {'tags' => tags }}})
   end
 
+  def add_tags(tags)
+    tags_data = tags.map { |tag| {type: 'tags', id: tag} }
+    @connection.post("creations/#{id}/tags", body: { data: tags_data })
+  end
+
+  def remove_tags(tags)
+    tags_data = tags.map { |tag| {type: 'tags', id: tag} }
+    @connection.delete("creations/#{id}/tags", body: { data: tags_data })
+  end
+
   def upload(file)
     extension = File.extname(file)[1..-1]
     res = @connection.post("creations/#{id}/uploads", :params => { 'extension' => extension })

--- a/spec/creatubbles/creation_spec.rb
+++ b/spec/creatubbles/creation_spec.rb
@@ -38,4 +38,30 @@ describe Creatubbles::Creation do
       expect(subject.creators).to eq ['xUt6Feou']
     end
   end
+
+  describe 'add_tags' do
+    it "should trigger post on connection with correct params" do
+      expect(connection).to receive(:post).with(
+        "creations/#{subject.id}/tags", {
+          body: {
+            data: [
+              { type: "tags", id: "a" },
+              { type: "tags", id: "b" }
+            ]}})
+      subject.add_tags(['a', 'b'])
+    end
+  end
+
+  describe 'remove_tags' do
+    it "should trigger post on connection with correct params" do
+      expect(connection).to receive(:delete).with(
+        "creations/#{subject.id}/tags", {
+          body: {
+            data: [
+              { type: "tags", id: "a" },
+              { type: "tags", id: "b" }
+            ]}})
+      subject.remove_tags(['a', 'b'])
+    end
+  end
 end


### PR DESCRIPTION
`update_tags` replaces creation's tags with new set of tags. The new methods can be used to to add or remove tags to/from creation's tag list.