### PR TITLE
269 warehouse get creation 403 retry mechanism

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,11 @@ group :development do
   gem 'rake'
   gem 'rspec'
 end
+
+group :test do
+  gem 'rake'
+  gem 'rspec'
+  gem 'webmock'
+  gem 'sinatra'
+  gem 'pry'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby '2.4.1'
+
 gemspec
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,5 +86,8 @@ DEPENDENCIES
   sinatra
   webmock
 
+RUBY VERSION
+   ruby 2.4.1p111
+
 BUNDLED WITH
    1.15.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,23 +13,38 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    coderay (1.1.1)
     concurrent-ruby (1.0.4)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     faraday (0.10.1)
       multipart-post (>= 1.2, < 3)
+    hashdiff (0.3.4)
     i18n (0.8.0)
     jwt (1.5.6)
+    method_source (0.8.2)
     minitest (5.10.1)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mustermann (1.0.0)
     oauth2 (1.3.0)
       faraday (>= 0.8, < 0.11)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    public_suffix (2.0.5)
     rack (2.0.1)
+    rack-protection (2.0.0)
+      rack
     rake (11.2.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -44,17 +59,32 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    safe_yaml (1.0.4)
+    sinatra (2.0.0)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0)
+      tilt (~> 2.0)
+    slop (3.6.0)
     thread_safe (0.3.5)
+    tilt (2.0.8)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    webmock (3.0.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   creatubbles!
+  pry
   rake
   rspec
+  sinatra
+  webmock
 
 BUNDLED WITH
-   1.14.3
+   1.15.3

--- a/lib/creatubbles.rb
+++ b/lib/creatubbles.rb
@@ -42,6 +42,7 @@ module Creatubbles
 
 end
 
+require "creatubbles/error"
 require "creatubbles/utils/auth_details"
 require "creatubbles/content"
 require "creatubbles/contents"

--- a/lib/creatubbles/base_collection.rb
+++ b/lib/creatubbles/base_collection.rb
@@ -13,15 +13,21 @@ class Creatubbles::BaseCollection
     @connection = connection
   end
 
-  def find(id,opts={nil_404:false})
+  def find(id)
     res = @connection.get("#{self.class.type_name}/#{id}")
     Creatubbles.instantiate_object_from_response(res, @connection)
   rescue => e
-    if opts[:nil_404] && is_record_not_found_404?(e)
-      return nil
+    if is_record_not_found_404?(e)
+      raise Creatubbles::Error::RecordNotFound.new(e), "Not Found! #{self.class.type_name}/#{id}"
     else
       raise e
     end
+  end
+
+  def find_by_id(id)
+    find(id)
+  rescue Creatubbles::Error::RecordNotFound
+    return nil
   end
 
   def init_objects(response)

--- a/lib/creatubbles/error.rb
+++ b/lib/creatubbles/error.rb
@@ -1,0 +1,11 @@
+module Creatubbles
+  module Error
+    #Creatubbles::Error::RecordNotFound
+    class RecordNotFound < StandardError
+      attr_reader :original
+      def initialize original
+        @original = original
+      end
+    end
+  end
+end

--- a/spec/creatubbles/base_collection_spec.rb
+++ b/spec/creatubbles/base_collection_spec.rb
@@ -6,12 +6,16 @@ RSpec.describe Creatubbles::BaseCollection do
     client = Creatubbles::Client.dummy
 
     expect{client.test_objects.find('non-existing-object-id')}.
-      to raise_error(OAuth2::Error)
+      to raise_error(Creatubbles::Error::RecordNotFound)
 
-    expect{client.test_objects.find('non-existing-object-id', nil_404:true)}.
-      not_to raise_error
+    begin
+      client.test_objects.find('non-existing-object-id')
+    rescue => e
+      expect(e.original).to be_a(OAuth2::Error)
+      expect(e.message).to include('non-existing-object-id')
+    end
 
-    expect(client.test_objects.find('non-existing-object-id', nil_404:true)).
+    expect(client.test_objects.find_by_id('non-existing-object-id')).
       to be_nil
   end
 end

--- a/spec/creatubbles/base_collection_spec.rb
+++ b/spec/creatubbles/base_collection_spec.rb
@@ -10,5 +10,8 @@ RSpec.describe Creatubbles::BaseCollection do
 
     expect{client.test_objects.find('non-existing-object-id', nil_404:true)}.
       not_to raise_error
+
+    expect(client.test_objects.find('non-existing-object-id', nil_404:true)).
+      to be_nil
   end
 end

--- a/spec/creatubbles/base_collection_spec.rb
+++ b/spec/creatubbles/base_collection_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe Creatubbles::BaseCollection do
+
+  it "ignores deleted creation" do
+    client = Creatubbles::Client.dummy
+
+    expect{client.test_objects.find('non-existing-object-id')}.
+      to raise_error(OAuth2::Error)
+
+    expect{client.test_objects.find('non-existing-object-id', nil_404:true)}.
+      not_to raise_error
+  end
+end

--- a/spec/creatubbles/creation_spec.rb
+++ b/spec/creatubbles/creation_spec.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require 'spec_helper'
 
 describe Creatubbles::Creation do
   let(:client) { Creatubbles::Client.new }

--- a/spec/creatubbles/user_spec.rb
+++ b/spec/creatubbles/user_spec.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require 'spec_helper'
 
 describe Creatubbles::User do
   let(:client) { Creatubbles::Client.new }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,21 @@
 require 'oauth2'
 require 'rspec'
 require 'creatubbles'
+require 'sinatra/base'
+require 'webmock/rspec'
+require 'pry'
 
 Dir['spec/support/**/*.rb'].each do |f|
   require f.gsub('spec/', '').gsub('.rb', '')
 end
 
+WebMock.disable_net_connect!(allow_localhost: true)
+
 RSpec.configure do |config|
+  config.before(:each) do
+    stub_request(:any, /api.creatubbles.com/).to_rack(Creatubbles::MockAPI)
+  end
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end

--- a/spec/support/creatubbles_mock_api.rb
+++ b/spec/support/creatubbles_mock_api.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Creatubbles
+  class MockAPI < Sinatra::Base
+    set :port, 3000
+
+    # put class variables here
+    # you cannot use @var in Sinatra::Base
+    configure do
+    end
+
+    # return a preset access token
+    post '/oauth/token' do
+      headers "Content-Type" => 'application/json'
+      {"access_token" => "a8c814aa3cee2d5cdca997a314dca206335c119e7121e954a7c6f17592caa33d", "token_type" => "bearer", "created_at" => 1479918313}.to_json
+    end
+
+    post '/v2/oauth/token' do
+      headers "Content-Type" => 'application/json'
+      {"access_token" => "a8c814aa3cee2d5cdca997a314dca206335c119e7121e954a7c6f17592caa33d", "token_type" => "bearer", "created_at" => 1479918313}.to_json
+    end
+
+    # get a non existing object
+    get '/v2/test_objects/non-existing-object-id' do
+      status 404
+      headers "Content-Type" => 'application/json'
+      "{\"errors\":[{\"status\":\"404\",\"code\":\"not_found\",\"source\":\"https://api.creatubbles.com/v2/objects/non-existing-creation-id\",\"title\":\"Not found\",\"detail\":\"Record not found\"}]}"
+    end
+
+  end
+end
+
+# To run the moch as a separate process:
+# Creatubbles::MockAPI.run!

--- a/spec/support/dummy_client.rb
+++ b/spec/support/dummy_client.rb
@@ -1,0 +1,22 @@
+module Creatubbles
+  class Client
+
+    def self.dummy_auth_details
+      {
+        client_id: "dummy_id",
+        client_secret: "dummy_secret",
+        api_url: "https://api.creatubbles.com/v2"
+      }
+    end
+
+    def self.dummy
+      new(dummy_auth_details)
+    end
+
+    Creatubbles::BaseCollection.define_type_name('test_objects')
+
+    def test_objects
+      Creatubbles::BaseCollection.new(connection)
+    end
+  end
+end


### PR DESCRIPTION
Provide an easy way to just return nil, when a resource does not exist.

Example:
```ruby
client.creations.find('noExist') -> excpetion
client.creations.find('noExist', nil_404:true) -> nil
```